### PR TITLE
Update Portainer usage

### DIFF
--- a/docs/docker.md
+++ b/docs/docker.md
@@ -192,15 +192,11 @@ Type "help" for help.
 postgres=#
 ```
 
-## Portainer
-Portainer(https://www.portainer.io) is a software for build and manage Docker environments in an easy and graphical way.
+## Portainer usage
 
-For Portainer use `docker-compose-portainer.yml` file and in plus of env vars before, set the follow mandatory env vars:
+Portainer (https://www.portainer.io) is a docker-based web application used to edit and manage Docker applications in a simple and intuitive way.
 
-* G3WSUITE_DOCKER_INSTALL_DIR: host directory where this code is.
-* PG_PUBLIC_PORT: host port to map Docker PostgreSql default port (5432).
-* WEBGIS_HTTP_PORT: host port to map Docker Nginx port (8080).
-* WEBGIS_HTTPS_PORT: host port to map Docker Nginx port (443).
+Plese refer to the [Add new stack](https://docs.portainer.io/v/ce-2.9/user/docker/stacks/add) section to learn how to deploy the `docker-compose-consumer.yml` stack with Portainer (>= v2.1.1).
 
 ### Contributors
 * Walter Lorenzetti - Gis3W ([@wlorenzetti](https://github.com/wlorenzetti))


### PR DESCRIPTION
Related to: https://github.com/g3w-suite/g3w-suite-docker/pull/72

I have never used [read the docs](readthedocs.org/) before, can anyone tell me if i also need to update the following file manually?

---

**Before:** [g3w-admin/docs/locales/en/LC_MESSAGES/docker.po#L356-L370](https://github.com/g3w-suite/g3w-admin/blob/5055049ada4c6daa90d4c9494756009d0aa34576/docs/locales/en/LC_MESSAGES/docker.po#L356-L370)

---

```po
#: ../../docker.md:193
msgid "Portainer"
msgstr ""

#: ../../docker.md:194
msgid ""
"Portainer(https://www.portainer.io) is a software for build and manage "
"Docker environments in an easy and graphical way."
msgstr ""

#: ../../docker.md:196
msgid ""
"For Portainer use docker-compose-portainer.yml file and in plus of env "
"vars before, set the follow mandatory env vars:"
msgstr ""
```

---

**After ?** [g3w-admin/docs/docker.md?plain=1#L195-L203](https://github.com/g3w-suite/g3w-admin/blob/5055049ada4c6daa90d4c9494756009d0aa34576/docs/docker.md?plain=1#L195-L203)

---

```diff
- ## Portainer
- Portainer(https://www.portainer.io) is a software for build and manage Docker environments in an easy and graphical way.
- For Portainer use `docker-compose-portainer.yml` file and in plus of env vars before, set the follow mandatory env vars:
- * G3WSUITE_DOCKER_INSTALL_DIR: host directory where this code is.
- * PG_PUBLIC_PORT: host port to map Docker PostgreSql default port (5432).
- * WEBGIS_HTTP_PORT: host port to map Docker Nginx port (8080).
- * WEBGIS_HTTPS_PORT: host port to map Docker Nginx port (443).

+ ## Portainer usage
+
+ Portainer (https://www.portainer.io) is a docker-based web application used to edit and manage Docker applications in a simple and intuitive way.
+
+ Plese refer to the [Add new stack](https://docs.portainer.io/v/ce-2.9/user/docker/stacks/add) section to learn how to deploy the `docker-compose-consumer.yml` stack with Portainer (>= v2.1.1).
 ```
